### PR TITLE
Feature/visual effects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ bin/
 #Code::Blocks
 *.cbp
 *.layout
+
+#vim
+*.swp

--- a/src/game/Game.cpp
+++ b/src/game/Game.cpp
@@ -72,14 +72,14 @@ bool Game::init() {
             success = false;
         } else {
             //Create renderer for window
-            Renderer::instance()->setWindow(window.getWindow());
-            if (Renderer::instance()->getRenderer()  == nullptr) {
+            Renderer::instance().setWindow(window.getWindow());
+            if (Renderer::instance().getRenderer()  == nullptr) {
                 logv("Renderer could not be created! SDL Error: %s\n", SDL_GetError());
                 success = false;
             } else {
 
                 //Initialize renderer color
-                SDL_SetRenderDrawColor(Renderer::instance()->getRenderer() , 0xFF, 0xFF, 0xFF, 0xFF);
+                SDL_SetRenderDrawColor(Renderer::instance().getRenderer() , 0xFF, 0xFF, 0xFF, 0xFF);
 
                 //Initialize PNG loading
                 int imgFlags = IMG_INIT_PNG;
@@ -108,7 +108,7 @@ bool Game::init() {
 }
 
 bool Game::loadMedia() {
-    Renderer::instance()->loadSprites();
+    Renderer::instance().loadSprites();
     return true;
 }
 

--- a/src/game/GameManager.cpp
+++ b/src/game/GameManager.cpp
@@ -38,7 +38,7 @@ void GameManager::renderObjects(const SDL_Rect& cam) {
     for (const auto& m : weaponDropManager) {
         if (m.second.getX() - camX < camW) {
             if (m.second.getY() - camY < camH) {
-                Renderer::instance()->render(m.second.getRelativeDestRect(cam), TEXTURES::CONCRETE);
+                Renderer::instance().render(m.second.getRelativeDestRect(cam), TEXTURES::CONCRETE);
             }
         }
     }
@@ -46,7 +46,7 @@ void GameManager::renderObjects(const SDL_Rect& cam) {
     for (const auto& m : marineManager) {
         if (m.second.getX() - camX < camW) {
             if (m.second.getY() - camY < camH) {
-                Renderer::instance()->render(m.second.getRelativeDestRect(cam), TEXTURES::MARINE,
+                Renderer::instance().render(m.second.getRelativeDestRect(cam), TEXTURES::MARINE,
                     m.second.getAngle());
             }
         }
@@ -56,7 +56,7 @@ void GameManager::renderObjects(const SDL_Rect& cam) {
     for (const auto& o : objectManager) {
         if (o.second.getX() < camW) {
             if (o.second.getY() - camY < camH) {
-                Renderer::instance()->render(o.second.getRelativeDestRect(cam), TEXTURES::CONCRETE);
+                Renderer::instance().render(o.second.getRelativeDestRect(cam), TEXTURES::CONCRETE);
             }
         }
     }
@@ -64,7 +64,7 @@ void GameManager::renderObjects(const SDL_Rect& cam) {
     for (const auto& z : zombieManager) {
         if (z.second.getX() - camX < camW) {
             if (z.second.getY() - camY < camH) {
-                Renderer::instance()->render(z.second.getRelativeDestRect(cam), TEXTURES::BABY_ZOMBIE);
+                Renderer::instance().render(z.second.getRelativeDestRect(cam), TEXTURES::BABY_ZOMBIE);
             }
         }
     }
@@ -72,7 +72,7 @@ void GameManager::renderObjects(const SDL_Rect& cam) {
     for (const auto& m : turretManager) {
         if (m.second.getX() - camX < camW) {
             if (m.second.getY() - camY < camH) {
-                Renderer::instance()->render(m.second.getRelativeDestRect(cam), TEXTURES::CONCRETE,
+                Renderer::instance().render(m.second.getRelativeDestRect(cam), TEXTURES::CONCRETE,
                     m.second.getAngle());
             }
         }
@@ -81,7 +81,7 @@ void GameManager::renderObjects(const SDL_Rect& cam) {
     for (const auto& b : barricadeManager) {
         if (b.second.getX() - camX < camW) {
             if (b.second.getY() - camY < camH) {
-                Renderer::instance()->render(b.second.getRelativeDestRect(cam), TEXTURES::CONCRETE);
+                Renderer::instance().render(b.second.getRelativeDestRect(cam), TEXTURES::CONCRETE);
             }
         }
     }
@@ -89,7 +89,7 @@ void GameManager::renderObjects(const SDL_Rect& cam) {
     for (const auto& w : wallManager) {
         if (w.second.getX() - camX < camW) {
             if (w.second.getY() - camY < camH) {
-                Renderer::instance()->render(w.second.getRelativeDestRect(cam), TEXTURES::CONCRETE);
+                Renderer::instance().render(w.second.getRelativeDestRect(cam), TEXTURES::CONCRETE);
             }
         }
     }

--- a/src/game/GameStateMatch.cpp
+++ b/src/game/GameStateMatch.cpp
@@ -13,6 +13,7 @@
 #include "../basic/LTimer.h"
 #include "../view/Window.h"
 #include "../log/log.h"
+#include "../sprites/VisualEffect.h"
 
 GameStateMatch::GameStateMatch(Game& g,  int gameWidth, int gameHeight) : GameState(g), player(),
     base(), camera(gameWidth,gameHeight) {
@@ -78,6 +79,7 @@ void GameStateMatch::loop() {
         update(stepTimer.getTicks() / TIME_SECOND); // Update state values
         stepTimer.start(); //Restart step timer
         sync();    // Sync game to server
+
         render();    // Render game state to window
 
         ++countedFrames;
@@ -116,7 +118,7 @@ void GameStateMatch::handle() {
             break;
         case SDL_MOUSEBUTTONDOWN:
             if (event.button.button == SDL_BUTTON_RIGHT) {
-                player.handlePlacementClick(Renderer::instance()->getRenderer());
+                player.handlePlacementClick(Renderer::instance().getRenderer());
             }
             break;
         case SDL_KEYDOWN:
@@ -125,7 +127,7 @@ void GameStateMatch::handle() {
                     play = false;
                     break;
                 case SDLK_b:
-                    player.handleTempBarricade(Renderer::instance()->getRenderer());
+                    player.handleTempBarricade(Renderer::instance().getRenderer());
                     break;
                 default:
                     break;
@@ -163,7 +165,7 @@ void GameStateMatch::render() {
     //Only draw when not minimized
     if (!game.window.isMinimized()) {
 
-        SDL_RenderClear(Renderer::instance()->getRenderer());
+        SDL_RenderClear(Renderer::instance().getRenderer());
 
         //Render textures
         for (int i = camera.getX() / TEXTURE_SIZE - 1; ; ++i) {
@@ -177,16 +179,20 @@ void GameStateMatch::render() {
                     break;
                 }
 
-                Renderer::instance()->render(
-                        {i * TEXTURE_SIZE - camera.getX(), j * TEXTURE_SIZE -camera.getY(), TEXTURE_SIZE, TEXTURE_SIZE},
-                        TEXTURES::BARREN);
+                Renderer::instance().render(
+                        {i * TEXTURE_SIZE - static_cast<int>(camera.getX()), j * TEXTURE_SIZE - static_cast<int>(camera.getY()),
+                        TEXTURE_SIZE, TEXTURE_SIZE}, TEXTURES::BARREN);
             }
         }
 
+        //render the temps before the objects in the game
+        VisualEffect::instance().renderPreEntity(camera.getViewport());
         //renders objects in game
         GameManager::instance()->renderObjects(camera.getViewport());
+        //render the temps after the object in the game
+        VisualEffect::instance().renderPostEntity(camera.getViewport());
 
         //Update screen
-        SDL_RenderPresent(Renderer::instance()->getRenderer());
+        SDL_RenderPresent(Renderer::instance().getRenderer());
     }
 }

--- a/src/game/GameStateMenu.cpp
+++ b/src/game/GameStateMenu.cpp
@@ -78,18 +78,23 @@ GameStateMenu::GameStateMenu(Game& g):GameState(g), headingFont(nullptr), textbo
 bool GameStateMenu::load() {
     logv("Loading Fonts...\n");
 
-    if ((menuFont = Renderer::instance().loadFont("assets/fonts/Overdrive Sunset.otf", 110)) == nullptr) {
+    if ((menuFont = Renderer::instance().loadFont("assets/fonts/Overdrive Sunset.otf", 
+            110)) == nullptr) {
         return false;
     }
 
-    Renderer::instance().createText(TEXTURES::JOIN_FONT, menuFont, "Join", SDL_Color{MAX_RGB, MAX_RGB, MAX_RGB, MAX_RGB});
-    Renderer::instance().createText(TEXTURES::OPTIONS_FONT, menuFont, "Options", SDL_Color{MAX_RGB, MAX_RGB, MAX_RGB, MAX_RGB});
+    Renderer::instance().createText(TEXTURES::JOIN_FONT, menuFont, "Join", 
+        SDL_Color{MAX_RGB, MAX_RGB, MAX_RGB, MAX_RGB});
+    Renderer::instance().createText(TEXTURES::OPTIONS_FONT, menuFont, "Options", 
+        SDL_Color{MAX_RGB, MAX_RGB, MAX_RGB, MAX_RGB});
 
-    if ((headingFont = Renderer::instance().loadFont("assets/fonts/SEGUISB.ttf", FONT_SIZE)) == nullptr) {
+    if ((headingFont = Renderer::instance().loadFont("assets/fonts/SEGUISB.ttf", 
+            FONT_SIZE)) == nullptr) {
         return false;
     }
 
-    if ((textboxFont = Renderer::instance().loadFont("assets/fonts/SEGOEUISL.ttf", FONT_SIZE)) == nullptr) {
+    if ((textboxFont = Renderer::instance().loadFont("assets/fonts/SEGOEUISL.ttf", 
+            FONT_SIZE)) == nullptr) {
         return false;
     }
 

--- a/src/game/GameStateMenu.cpp
+++ b/src/game/GameStateMenu.cpp
@@ -78,18 +78,18 @@ GameStateMenu::GameStateMenu(Game& g):GameState(g), headingFont(nullptr), textbo
 bool GameStateMenu::load() {
     logv("Loading Fonts...\n");
 
-    if ((menuFont = Renderer::instance()->loadFont("assets/fonts/Overdrive Sunset.otf", 110)) == nullptr) {
+    if ((menuFont = Renderer::instance().loadFont("assets/fonts/Overdrive Sunset.otf", 110)) == nullptr) {
         return false;
     }
 
-    Renderer::instance()->createText(TEXTURES::JOIN_FONT, menuFont, "Join", SDL_Color{MAX_RGB, MAX_RGB, MAX_RGB, MAX_RGB});
-    Renderer::instance()->createText(TEXTURES::OPTIONS_FONT, menuFont, "Options", SDL_Color{MAX_RGB, MAX_RGB, MAX_RGB, MAX_RGB});
+    Renderer::instance().createText(TEXTURES::JOIN_FONT, menuFont, "Join", SDL_Color{MAX_RGB, MAX_RGB, MAX_RGB, MAX_RGB});
+    Renderer::instance().createText(TEXTURES::OPTIONS_FONT, menuFont, "Options", SDL_Color{MAX_RGB, MAX_RGB, MAX_RGB, MAX_RGB});
 
-    if ((headingFont = Renderer::instance()->loadFont("assets/fonts/SEGUISB.ttf", FONT_SIZE)) == nullptr) {
+    if ((headingFont = Renderer::instance().loadFont("assets/fonts/SEGUISB.ttf", FONT_SIZE)) == nullptr) {
         return false;
     }
 
-    if ((textboxFont = Renderer::instance()->loadFont("assets/fonts/SEGOEUISL.ttf", FONT_SIZE)) == nullptr) {
+    if ((textboxFont = Renderer::instance().loadFont("assets/fonts/SEGOEUISL.ttf", FONT_SIZE)) == nullptr) {
         return false;
     }
 
@@ -360,24 +360,24 @@ void GameStateMenu::render() {
         screenRect = {ZERO, ZERO, game.window.getWidth(), game.window.getHeight()};
 
         //Clear screen
-        SDL_RenderClear(Renderer::instance()->getRenderer());
+        SDL_RenderClear(Renderer::instance().getRenderer());
 
         //render the splash screen
-        Renderer::instance()->render(screenRect, TEXTURES::MAIN);
+        Renderer::instance().render(screenRect, TEXTURES::MAIN);
 
         //Position all screen elements in the window
         positionElements();
 
         //textboxes
-        Renderer::instance()->render(usernameTextBox, TEXTURES::TEXTBOX);
-        Renderer::instance()->render(hostIPTextBox, TEXTURES::TEXTBOX);
+        Renderer::instance().render(usernameTextBox, TEXTURES::TEXTBOX);
+        Renderer::instance().render(hostIPTextBox, TEXTURES::TEXTBOX);
 
         //Join and Options text
-        Renderer::instance()->render(joinRect, TEXTURES::JOIN_FONT);
-        Renderer::instance()->render(optionsRect, TEXTURES::OPTIONS_FONT);
+        Renderer::instance().render(joinRect, TEXTURES::JOIN_FONT);
+        Renderer::instance().render(optionsRect, TEXTURES::OPTIONS_FONT);
 
         //Update screen
-        SDL_RenderPresent(Renderer::instance()->getRenderer());
+        SDL_RenderPresent(Renderer::instance().getRenderer());
     }
 }
 

--- a/src/inventory/weapons/InstantWeapon.cpp
+++ b/src/inventory/weapons/InstantWeapon.cpp
@@ -38,15 +38,19 @@ void InstantWeapon::fire(Marine &marine){
     std::priority_queue<const HitBox*> targets;
     targets = collisionHandler.detectLineCollision(marine, getRange());
    
-    //same as what happens in the line collision to show the use of the effect
+
+    //similar as to what happens in the line collision and is used to show a use of the line effect
     const double degrees = marine.getAngle() - 90;
     const double radians = degrees * M_PI / 180;
     const int playerX = marine.getX() + (MARINE_WIDTH / 2);
     const int playerY = marine.getY() + (MARINE_HEIGHT / 2);
-    const int deltaX  = range * cos(radians);
-    const int deltaY  = range * sin(radians);
+    const int deltaX  = playerX + range * cos(radians);
+    const int deltaY  = playerY + range * sin(radians);
 
-    VisualEffect::instance().addPostLine(5, playerX, playerY, playerX + deltaX, playerY + deltaY, 0, 255, 0);
+    //5 frames to display ie 1/12th of a second at 60fps
+    //0 red, 255 green, 0 blue
+    VisualEffect::instance().addPreLine(5, playerX, playerY, deltaX, deltaY, 0, 255, 0);
+
     if(targets.empty()){
         return;
     }

--- a/src/inventory/weapons/InstantWeapon.cpp
+++ b/src/inventory/weapons/InstantWeapon.cpp
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <iostream>
 #include "../../log/log.h"
+#include "../../sprites/VisualEffect.h"
 
 InstantWeapon::InstantWeapon(std::string type, int range, int damage,
         int clip, int clipMax, int ammo, int AOE, int reloadSpeed, int fireRate, bool isReadyToFire)
@@ -36,6 +37,16 @@ void InstantWeapon::fire(Marine &marine){
     //get all targets in line with the shot
     std::priority_queue<const HitBox*> targets;
     targets = collisionHandler.detectLineCollision(marine, getRange());
+   
+    //same as what happens in the line collision to show the use of the effect
+    const double degrees = marine.getAngle() - 90;
+    const double radians = degrees * M_PI / 180;
+    const int playerX = marine.getX() + (MARINE_WIDTH / 2);
+    const int playerY = marine.getY() + (MARINE_HEIGHT / 2);
+    const int deltaX  = range * cos(radians);
+    const int deltaY  = range * sin(radians);
+
+    VisualEffect::instance().addPostLine(5, playerX, playerY, playerX + deltaX, playerY + deltaY, 0, 255, 0);
     if(targets.empty()){
         return;
     }

--- a/src/sprites/Renderer.cpp
+++ b/src/sprites/Renderer.cpp
@@ -77,7 +77,7 @@ void Renderer::loadSprites() {
  *
  * Loads a font from a TTF file
  */
-TTF_Font * Renderer::loadFont(const std::string filePath, const int size) {
+TTF_Font* Renderer::loadFont(const std::string& filePath, const int size) {
     TTF_Font * font = nullptr;
 
     if ((font = TTF_OpenFont(filePath.c_str(), size)) == nullptr) {
@@ -93,7 +93,7 @@ TTF_Font * Renderer::loadFont(const std::string filePath, const int size) {
  * DATE:      March 14, 2017
  * creates a texture and adds it to the array
  */
-void Renderer::createTexture(const int index, const std::string filePath) {
+void Renderer::createTexture(const int index, const std::string& filePath) {
 
     SDL_Surface * surface = IMG_Load(filePath.c_str());
 
@@ -116,7 +116,7 @@ void Renderer::createTexture(const int index, const std::string filePath) {
     }
 }
 
-void Renderer::createTexture(const TEXTURES index, const std::string filePath) {
+void Renderer::createTexture(const TEXTURES index, const std::string& filePath) {
     createTexture(static_cast<int>(index), filePath);
 }
 
@@ -126,7 +126,7 @@ void Renderer::createTexture(const TEXTURES index, const std::string filePath) {
  * DATE:      March 20, 2017
  * creates a texture, adds it to the map and returns its ID
  */
-int Renderer::createTempTexture(const std::string filePath) {
+int Renderer::createTempTexture(const std::string& filePath) {
     createTexture(tempIndex, filePath);
     return tempIndex++;
 }
@@ -138,7 +138,7 @@ int Renderer::createTempTexture(const std::string filePath) {
  * creates a texture out of text
  * returns a 0 on error, otherwise returns the id where it is stored
  */
-void Renderer::createText(const TEXTURES index, TTF_Font * font, const std::string text, const SDL_Color colour) {
+void Renderer::createText(const TEXTURES index, TTF_Font* font, const std::string& text, const SDL_Color& colour) {
     SDL_Surface * textSurface = TTF_RenderText_Solid(font, text.c_str(), colour);
 
     if (textSurface == nullptr) {
@@ -164,7 +164,7 @@ void Renderer::createText(const TEXTURES index, TTF_Font * font, const std::stri
  * creates a texture out of text, used for temporary texts (usernames, ect)
  * returns a 0 on error, otherwise returns the id where it is stored
  */
-int Renderer::createTempText(TTF_Font * font, const std::string text, const SDL_Color colour) {
+int Renderer::createTempText(TTF_Font * font, const std::string& text, const SDL_Color& colour) {
     SDL_Surface * textSurface = TTF_RenderText_Solid(font, text.c_str(), colour);
 
     if (textSurface == nullptr) {

--- a/src/sprites/Renderer.cpp
+++ b/src/sprites/Renderer.cpp
@@ -2,31 +2,19 @@
 #include "../view/Window.h"
 #include "../log/log.h"
 
-/* DEVELOPER: Michael Goll
-** DESIGNER:  Michael Goll
-** DATE:      March 14, 2017
-*/
+/**
+ * DEVELOPER: Michael Goll
+ * DESIGNER:  Michael Goll
+ * DATE:      March 14, 2017
+ */
 
-Renderer Renderer::rInstance;
-SDL_Renderer * Renderer::renderer = nullptr;
-SDL_Window * Renderer::window = nullptr;
+Renderer Renderer::sInstance;
 
-std::map<int, SDL_Texture *> Renderer::sprites;
-int Renderer::tempIndex = 1000;
-
-/* DEVELOPER: Michael Goll
-** DESIGNER:  Michael Goll
-** DATE:      March 14, 2017
-** returns the instance if it exists, otherwise creates one
-*/
-Renderer * Renderer::instance() {
-    return &Renderer::rInstance;
-}
-
-/* DEVELOPER: Michael Goll
-** DESIGNER:  Michael Goll
-** DATE:      March 14, 2017
-*/
+/**
+ * DEVELOPER: Michael Goll
+ * DESIGNER:  Michael Goll
+ * DATE:      March 14, 2017
+ */
 Renderer::~Renderer() {
     for (const auto& s : sprites) {
         if (s.second != nullptr) {
@@ -38,11 +26,12 @@ Renderer::~Renderer() {
     SDL_DestroyWindow(window);
 }
 
-/* DEVELOPER: Michael Goll
-** DESIGNER:  Michael Goll
-** DATE:      March 14, 2017
-** load all sprites sheets
-*/
+/**
+ * DEVELOPER: Michael Goll
+ * DESIGNER:  Michael Goll
+ * DATE:      March 14, 2017
+ * load all sprites sheets
+ */
 void Renderer::loadSprites() {
     logv("Loading Sprites...\n");
     //Main game screen
@@ -78,11 +67,16 @@ void Renderer::loadSprites() {
     createTexture(TEXTURES::BOSS_ZOMBIE, ZOMBIE_BOSS);
 }
 
-/* DEVELOPER: Michael Goll
-** DESIGNER:  Michael Goll
-** DATE:      March 14, 2017
-** Loads a font from a TTF file
-*/
+/**
+ * DEVELOPER: Michael Goll
+ * DESIGNER:  Michael Goll
+ * DATE:      March 14, 2017
+ *
+ * REVISED: Isaac Morneau, March 25, 2017
+ *      changed pointers and static to references
+ *
+ * Loads a font from a TTF file
+ */
 TTF_Font * Renderer::loadFont(const std::string filePath, const int size) {
     TTF_Font * font = nullptr;
 
@@ -93,11 +87,12 @@ TTF_Font * Renderer::loadFont(const std::string filePath, const int size) {
     return font;
 }
 
-/* DEVELOPER: Michael Goll
-** DESIGNER:  Michael Goll
-** DATE:      March 14, 2017
-** creates a texture and adds it to the array
-*/
+/**
+ * DEVELOPER: Michael Goll
+ * DESIGNER:  Michael Goll
+ * DATE:      March 14, 2017
+ * creates a texture and adds it to the array
+ */
 void Renderer::createTexture(const int index, const std::string filePath) {
 
     SDL_Surface * surface = IMG_Load(filePath.c_str());
@@ -125,22 +120,24 @@ void Renderer::createTexture(const TEXTURES index, const std::string filePath) {
     createTexture(static_cast<int>(index), filePath);
 }
 
-/* DEVELOPER: Michael Goll
-** DESIGNER:  Michael Goll
-** DATE:      March 20, 2017
-** creates a texture, adds it to the map and returns its ID
-*/
+/**
+ * DEVELOPER: Michael Goll
+ * DESIGNER:  Michael Goll
+ * DATE:      March 20, 2017
+ * creates a texture, adds it to the map and returns its ID
+ */
 int Renderer::createTempTexture(const std::string filePath) {
     createTexture(tempIndex, filePath);
     return tempIndex++;
 }
 
-/* DEVELOPER: Michael Goll
-** DESIGNER:  Michael Goll
-** DATE:      March 14, 2017
-** creates a texture out of text
-** returns a 0 on error, otherwise returns the id where it is stored
-*/
+/**
+ * DEVELOPER: Michael Goll
+ * DESIGNER:  Michael Goll
+ * DATE:      March 14, 2017
+ * creates a texture out of text
+ * returns a 0 on error, otherwise returns the id where it is stored
+ */
 void Renderer::createText(const TEXTURES index, TTF_Font * font, const std::string text, const SDL_Color colour) {
     SDL_Surface * textSurface = TTF_RenderText_Solid(font, text.c_str(), colour);
 
@@ -160,12 +157,13 @@ void Renderer::createText(const TEXTURES index, TTF_Font * font, const std::stri
     }
 }
 
-/* DEVELOPER: Michael Goll
-** DESIGNER:  Michael Goll
-** DATE:      March 20, 2017
-** creates a texture out of text, used for temporary texts (usernames, ect)
-** returns a 0 on error, otherwise returns the id where it is stored
-*/
+/**
+ * DEVELOPER: Michael Goll
+ * DESIGNER:  Michael Goll
+ * DATE:      March 20, 2017
+ * creates a texture out of text, used for temporary texts (usernames, ect)
+ * returns a 0 on error, otherwise returns the id where it is stored
+ */
 int Renderer::createTempText(TTF_Font * font, const std::string text, const SDL_Color colour) {
     SDL_Surface * textSurface = TTF_RenderText_Solid(font, text.c_str(), colour);
 
@@ -187,32 +185,35 @@ int Renderer::createTempText(TTF_Font * font, const std::string text, const SDL_
     return 0;
 }
 
-/* DEVELOPER: Michael Goll
-** DESIGNER:  Michael Goll
-** DATE:      March 14, 2017
-** sets the game's renderer
-*/
+/**
+ * DEVELOPER: Michael Goll
+ * DESIGNER:  Michael Goll
+ * DATE:      March 14, 2017
+ * sets the game's renderer
+ */
 void Renderer::setRenderer() {
     if ((renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED)) == nullptr) {
         logv("Renderer could not be created\n");
     }
 }
 
-/* DEVELOPER: Michael Goll
-** DESIGNER:  Michael Goll
-** DATE:      March 14, 2017
-** sets the window
-*/
+/**
+ * DEVELOPER: Michael Goll
+ * DESIGNER:  Michael Goll
+ * DATE:      March 14, 2017
+ * sets the window
+ */
 void Renderer::setWindow(SDL_Window * win) {
     window = win;
     setRenderer();
 }
 
-/* DEVELOPER: Michael Goll
-** DESIGNER:  Michael Goll
-** DATE:      March 14, 2017
-** renders an object
-*/
+/**
+ * DEVELOPER: Michael Goll
+ * DESIGNER:  Michael Goll
+ * DATE:      March 14, 2017
+ * renders an object
+ */
 void Renderer::render(const SDL_Rect& dest, const TEXTURES spriteType, const SDL_Rect& clip,
     double angle, const SDL_Point* center, const SDL_RendererFlip flip) {
     //Render to screen
@@ -220,11 +221,12 @@ void Renderer::render(const SDL_Rect& dest, const TEXTURES spriteType, const SDL
                      center, flip);
 }
 
-/* DEVELOPER: Michael Goll
-** DESIGNER:  Michael Goll
-** DATE:      March 14, 2017
-** renders an object
-*/
+/**
+ * DEVELOPER: Michael Goll
+ * DESIGNER:  Michael Goll
+ * DATE:      March 14, 2017
+ * renders an object
+ */
 void Renderer::render(const SDL_Rect& dest, const TEXTURES spriteType, double angle,
     const SDL_Point* center, const SDL_RendererFlip flip) {
     //Render to screen
@@ -232,11 +234,12 @@ void Renderer::render(const SDL_Rect& dest, const TEXTURES spriteType, double an
                      center, flip);
 }
 
-/* DEVELOPER: Michael Goll
-** DESIGNER:  Michael Goll
-** DATE:      March 14, 2017
-** returns the sprite or sprite sheet that the object is looking to render
-*/
+/**
+ * DEVELOPER: Michael Goll
+ * DESIGNER:  Michael Goll
+ * DATE:      March 14, 2017
+ * returns the sprite or sprite sheet that the object is looking to render
+ */
 SDL_Texture * Renderer::getTexture(int spriteType) {
     auto texture = sprites.find(spriteType);
 

--- a/src/sprites/Renderer.cpp
+++ b/src/sprites/Renderer.cpp
@@ -46,9 +46,9 @@ void Renderer::loadSprites() {
     createTexture(TEXTURES::CONCRETE, REPLACE_ME);     //concrete, temporary texture for now
 
     //-------- map object textures --------
-        //nature
-        //comsumables
-        //shops
+    //nature
+    //comsumables
+    //shops
     createTexture(TEXTURES::MAP_OBJECTS, MAP_OBJECTS);
 
     //-------- weapon textures --------
@@ -233,7 +233,7 @@ void Renderer::render(const SDL_Rect& dest, const int spriteType, const SDL_Rect
         double angle, const SDL_Point* center, const SDL_RendererFlip flip) {
     //Render to screen
     SDL_RenderCopyEx(renderer, getTexture(spriteType), &clip, &dest, angle,
-                     center, flip);
+            center, flip);
 }
 
 
@@ -245,7 +245,7 @@ void Renderer::render(const SDL_Rect& dest, const int spriteType, const SDL_Rect
  * texture is a scoped enum and is no longer auto converted
  */
 void Renderer::render(const SDL_Rect& dest, const TEXTURES spriteType, double angle,
-    const SDL_Point* center, const SDL_RendererFlip flip) {
+        const SDL_Point* center, const SDL_RendererFlip flip) {
     render(dest, static_cast<int>(spriteType), angle, center, flip);
 }
 
@@ -256,10 +256,10 @@ void Renderer::render(const SDL_Rect& dest, const TEXTURES spriteType, double an
  * renders an object
  */
 void Renderer::render(const SDL_Rect& dest, const int spriteType, double angle,
-    const SDL_Point* center, const SDL_RendererFlip flip) {
+        const SDL_Point* center, const SDL_RendererFlip flip) {
     //Render to screen
     SDL_RenderCopyEx(renderer, getTexture(spriteType), nullptr, &dest, angle,
-                     center, flip);
+            center, flip);
 }
 
 /**

--- a/src/sprites/Renderer.cpp
+++ b/src/sprites/Renderer.cpp
@@ -208,17 +208,45 @@ void Renderer::setWindow(SDL_Window * win) {
     setRenderer();
 }
 
+
+
+/**
+ * DEVELOPER: Isaac Morneau
+ * DESIGNER:  Isaac Morneau
+ * DATE:      March 14, 2017
+ * wraps the call using a texture to an int as
+ * texture is a scoped enum and is no longer auto converted
+ */
+void Renderer::render(const SDL_Rect& dest, const TEXTURES spriteType, const SDL_Rect& clip,
+        double angle, const SDL_Point* center, const SDL_RendererFlip flip) {
+    render(dest, static_cast<int>(spriteType), clip, angle, center, flip);
+}
 /**
  * DEVELOPER: Michael Goll
  * DESIGNER:  Michael Goll
  * DATE:      March 14, 2017
+ * REVISION:  Isaac Morneau, March 26, 2017
+ *      added duplicates to autowrap textures to ints
  * renders an object
  */
-void Renderer::render(const SDL_Rect& dest, const TEXTURES spriteType, const SDL_Rect& clip,
-    double angle, const SDL_Point* center, const SDL_RendererFlip flip) {
+void Renderer::render(const SDL_Rect& dest, const int spriteType, const SDL_Rect& clip,
+        double angle, const SDL_Point* center, const SDL_RendererFlip flip) {
     //Render to screen
-    SDL_RenderCopyEx(renderer, getTexture(static_cast<int>(spriteType)), &clip, &dest, angle,
+    SDL_RenderCopyEx(renderer, getTexture(spriteType), &clip, &dest, angle,
                      center, flip);
+}
+
+
+/**
+ * DEVELOPER: Isaac Morneau
+ * DESIGNER:  Isaac Morneau
+ * DATE:      March 14, 2017
+ * wraps the call using a texture to an int as
+ * texture is a scoped enum and is no longer auto converted
+ */
+void Renderer::render(const SDL_Rect& dest, const TEXTURES spriteType, double angle,
+    const SDL_Point* center, const SDL_RendererFlip flip) {
+    render(dest, static_cast<int>(spriteType), angle, center, flip);
 }
 
 /**
@@ -227,10 +255,10 @@ void Renderer::render(const SDL_Rect& dest, const TEXTURES spriteType, const SDL
  * DATE:      March 14, 2017
  * renders an object
  */
-void Renderer::render(const SDL_Rect& dest, const TEXTURES spriteType, double angle,
+void Renderer::render(const SDL_Rect& dest, const int spriteType, double angle,
     const SDL_Point* center, const SDL_RendererFlip flip) {
     //Render to screen
-    SDL_RenderCopyEx(renderer, getTexture(static_cast<int>(spriteType)), nullptr, &dest, angle,
+    SDL_RenderCopyEx(renderer, getTexture(spriteType), nullptr, &dest, angle,
                      center, flip);
 }
 

--- a/src/sprites/Renderer.h
+++ b/src/sprites/Renderer.h
@@ -116,7 +116,7 @@ class Renderer {
 
 
     private:
-        Renderer() = default;
+        Renderer(): tempIndex(1000) {}
         ~Renderer();
 
         static Renderer sInstance;

--- a/src/sprites/Renderer.h
+++ b/src/sprites/Renderer.h
@@ -59,7 +59,7 @@ static constexpr int TOTAL_SPRITES = 20; //number of total sprites
 
 
 class Renderer {
-    public:
+public:
 
 
         /**
@@ -96,40 +96,40 @@ class Renderer {
         //loads all the sprites specified in Renderer.h
         void loadSprites();
 
-        TTF_Font *loadFont(const std::string fonts, const int size);
+        TTF_Font *loadFont(const std::string& fonts, const int size);
 
         //creates a texture from a font file
-        void createText(const TEXTURES index, TTF_Font *font, const std::string text, const SDL_Color colour);
+        void createText(const TEXTURES index, TTF_Font *font, const std::string& text, const SDL_Color& colour);
 
-        int createTempText(TTF_Font *font, const std::string text, const SDL_Color colour);
+        int createTempText(TTF_Font *font, const std::string& text, const SDL_Color& colour);
 
         //creates a temporary texture
-        int createTempTexture(const std::string filePath);
+        int createTempTexture(const std::string& filePath);
 
         //renders all of the sprites within the camera viewport
-        void render(const SDL_Rect &dest, const TEXTURES spriteType, double angle = 0.0,
-            const SDL_Point *center = nullptr, const SDL_RendererFlip flip = SDL_FLIP_NONE);
+        void render(const SDL_Rect& dest, const TEXTURES spriteType, double angle = 0.0,
+                const SDL_Point *center = nullptr, const SDL_RendererFlip flip = SDL_FLIP_NONE);
 
         //renders all of the sprites within the camera viewport
-        void render(const SDL_Rect &dest, const TEXTURES spriteType, const SDL_Rect &clip, double angle = 0.0,
-            const SDL_Point *center = nullptr, const SDL_RendererFlip flip = SDL_FLIP_NONE);
+        void render(const SDL_Rect& dest, const TEXTURES spriteType, const SDL_Rect& clip, double angle = 0.0,
+                const SDL_Point *center = nullptr, const SDL_RendererFlip flip = SDL_FLIP_NONE);
 
 
-    private:
+private:
         Renderer(): tempIndex(1000) {}
         ~Renderer();
 
         static Renderer sInstance;
-        SDL_Renderer * renderer;
-        SDL_Window * window;
+        SDL_Renderer* renderer;
+        SDL_Window* window;
         int tempIndex;
 
         //array of all sprites in the game
-        std::map<int, SDL_Texture *> sprites;
+        std::map<int, SDL_Texture*> sprites;
 
         //creates a texture from a file
-        void createTexture(const TEXTURES index, const std::string filePath);
-        void createTexture(const int index, const std::string filePath);
+        void createTexture(const TEXTURES index, const std::string& filePath);
+        void createTexture(const int index, const std::string& filePath);
 
         //sets the renderer
         void setRenderer();

--- a/src/sprites/Renderer.h
+++ b/src/sprites/Renderer.h
@@ -11,10 +11,11 @@
 #include "../sprites/SpriteTypes.h"
 #include "../log/log.h"
 
-/* DEVELOPER: Michael Goll
-** DESIGNER:  Michael Goll
-** DATE:      March 14, 2017
-*/
+/*
+ * DEVELOPER: Michael Goll
+ * DESIGNER:  Michael Goll
+ * DATE:      March 14, 2017
+ */
 
 //-------- Game Screens --------
 const std::string MAIN_SCREEN = "assets/TitleScreen_Marz.png";
@@ -59,59 +60,79 @@ static constexpr int TOTAL_SPRITES = 20; //number of total sprites
 
 class Renderer {
     public:
-        //returns the instance if it exists, otherwise creates one
-        static Renderer * instance();
 
-        ~Renderer();
+
+        /**
+         * DEVELOPER: Michael Goll
+         * DESIGNER:  Michael Goll
+         * DATE:      March 14, 2017
+         *
+         * REVISED: Isaac Morneau, March 25, 2017
+         *      changed pointers and static to references
+         *
+         * returns the instance for rendering
+         */
+        static Renderer& instance() {
+            return sInstance;
+        }
+
 
         //returns the sprite or sprite sheet that the object is looking to render
-        static SDL_Texture * getTexture(int spriteType);
+        SDL_Texture *getTexture(int spriteType);
 
-        //gets the renderer
-        static SDL_Renderer * getRenderer() {return renderer;};
+        /**
+         * DEVELOPER: Michael Goll
+         * DESIGNER: Michael Goll
+         * DATE: March 14, 2017
+         * gets the rederer directly
+         */
+        SDL_Renderer *getRenderer() {
+            return renderer;
+        };
 
         //sets the window
-        static void setWindow(SDL_Window * win);
+        void setWindow(SDL_Window *win);
 
         //loads all the sprites specified in Renderer.h
-        static void loadSprites();
+        void loadSprites();
 
-        static TTF_Font * loadFont(const std::string fonts, const int size);
+        TTF_Font *loadFont(const std::string fonts, const int size);
 
         //creates a texture from a font file
-        void createText(const TEXTURES index, TTF_Font * font, const std::string text, const SDL_Color colour);
+        void createText(const TEXTURES index, TTF_Font *font, const std::string text, const SDL_Color colour);
 
-        int createTempText(TTF_Font * font, const std::string text, const SDL_Color colour);
+        int createTempText(TTF_Font *font, const std::string text, const SDL_Color colour);
 
         //creates a temporary texture
         int createTempTexture(const std::string filePath);
 
         //renders all of the sprites within the camera viewport
-        static void render(const SDL_Rect& dest, const TEXTURES spriteType, double angle = 0.0,
-            const SDL_Point* center = nullptr, const SDL_RendererFlip flip = SDL_FLIP_NONE);
+        void render(const SDL_Rect &dest, const TEXTURES spriteType, double angle = 0.0,
+            const SDL_Point *center = nullptr, const SDL_RendererFlip flip = SDL_FLIP_NONE);
 
         //renders all of the sprites within the camera viewport
-        static void render(const SDL_Rect& dest, const TEXTURES spriteType, const SDL_Rect& clip, double angle = 0.0,
-            const SDL_Point* center = nullptr, const SDL_RendererFlip flip = SDL_FLIP_NONE);
+        void render(const SDL_Rect &dest, const TEXTURES spriteType, const SDL_Rect &clip, double angle = 0.0,
+            const SDL_Point *center = nullptr, const SDL_RendererFlip flip = SDL_FLIP_NONE);
 
 
     private:
         Renderer() = default;
+        ~Renderer();
 
-        static Renderer rInstance;
-        static SDL_Renderer * renderer;
-        static SDL_Window * window;
-        static int tempIndex;
+        static Renderer sInstance;
+        SDL_Renderer * renderer;
+        SDL_Window * window;
+        int tempIndex;
 
         //array of all sprites in the game
-        static std::map<int, SDL_Texture *> sprites;
+        std::map<int, SDL_Texture *> sprites;
 
         //creates a texture from a file
-        static void createTexture(const TEXTURES index, const std::string filePath);
-        static void createTexture(const int index, const std::string filePath);
+        void createTexture(const TEXTURES index, const std::string filePath);
+        void createTexture(const int index, const std::string filePath);
 
         //sets the renderer
-        static void setRenderer();
+        void setRenderer();
 };
 
 #endif

--- a/src/sprites/Renderer.h
+++ b/src/sprites/Renderer.h
@@ -109,9 +109,13 @@ public:
         //renders all of the sprites within the camera viewport
         void render(const SDL_Rect& dest, const TEXTURES spriteType, double angle = 0.0,
                 const SDL_Point *center = nullptr, const SDL_RendererFlip flip = SDL_FLIP_NONE);
+        void render(const SDL_Rect& dest, const int spriteType, double angle = 0.0,
+                const SDL_Point *center = nullptr, const SDL_RendererFlip flip = SDL_FLIP_NONE);
 
         //renders all of the sprites within the camera viewport
         void render(const SDL_Rect& dest, const TEXTURES spriteType, const SDL_Rect& clip, double angle = 0.0,
+                const SDL_Point *center = nullptr, const SDL_RendererFlip flip = SDL_FLIP_NONE);
+        void render(const SDL_Rect& dest, const int spriteType, const SDL_Rect& clip, double angle = 0.0,
                 const SDL_Point *center = nullptr, const SDL_RendererFlip flip = SDL_FLIP_NONE);
 
 

--- a/src/sprites/VisualEffect.cpp
+++ b/src/sprites/VisualEffect.cpp
@@ -21,7 +21,7 @@ VisualEffect::VisualEffect():preLineId(0), preRectId(0), preTexId(0), postLineId
  * Notes:
  * helper function to calculate the screen rect based on the camera
  */
-inline const SDL_Rect relative(const SDL_Rect& dest, const SDL_Rect& camera){
+inline constexpr SDL_Rect relative(const SDL_Rect& dest, const SDL_Rect& camera){
     return {dest.x - camera.x, dest.y - camera.y, dest.w, dest.h};
 }
 

--- a/src/sprites/VisualEffect.cpp
+++ b/src/sprites/VisualEffect.cpp
@@ -1,0 +1,122 @@
+#include "VisualEffect.h"
+#include "Renderer.h"
+#include <SDL2/SDL.h>
+
+VisualEffect VisualEffect::sInstance;
+
+VisualEffect::VisualEffect():preLineId(0), preRectId(0), preTexId(0), postLineId(0),
+    postRectId(0), postTexId(0) { }
+
+inline const SDL_Rect relative(const SDL_Rect& dest, const SDL_Rect& camera){
+    return {dest.x - camera.x, dest.y - camera.y, dest.w, dest.h};
+}
+
+void VisualEffect::renderPreEntity(const SDL_Rect &camera) {
+    auto& renderer = Renderer::instance();
+    SDL_Renderer *rend = renderer.getRenderer();
+    for (auto& p : preLines) {
+        if (--p.second.dur > 0) {
+            SDL_SetRenderDrawColor(rend, p.second.r, p.second.g, p.second.b, p.second.a);
+            SDL_RenderDrawLine(rend, p.second.x - camera.x, p.second.y - camera.y,
+                    p.second.ex - camera.x, p.second.ey - camera.y);
+        }
+    }
+    for (auto& p : preRects) {
+        if (--p.second.dur > 0) {
+            SDL_SetRenderDrawColor(rend, p.second.r, p.second.g, p.second.b, p.second.a);
+            const SDL_Rect temp = relative(p.second.s, camera);
+            SDL_RenderDrawRect(rend, &temp);
+        }
+    } 
+    for (auto& p : preTex) {
+        if (--p.second.dur > 0) {
+            const SDL_Rect temp = relative(p.second.dest, camera);
+            renderer.render(temp, p.second.tex, p.second.src);
+        }
+    } 
+}
+
+void VisualEffect::renderPostEntity(const SDL_Rect &camera) {
+    auto& renderer = Renderer::instance();
+    SDL_Renderer *rend = renderer.getRenderer();
+    for (auto& p : postLines) {
+        if (--p.second.dur > 0) {
+            SDL_SetRenderDrawColor(rend, p.second.r, p.second.g, p.second.b, p.second.a);
+            SDL_RenderDrawLine(rend, p.second.x - camera.x, p.second.y - camera.y,
+                    p.second.ex - camera.x, p.second.ey - camera.y);
+        }
+    }
+    for (auto& p : postRects) {
+        if (--p.second.dur > 0) {
+            SDL_SetRenderDrawColor(rend, p.second.r, p.second.g, p.second.b, p.second.a);
+            const SDL_Rect temp = relative(p.second.s, camera);
+            SDL_RenderDrawRect(rend, &temp);
+        }
+    } 
+    for (auto& p : postTex) {
+        if (--p.second.dur > 0) {
+            const SDL_Rect temp = relative(p.second.dest, camera);
+            renderer.render(temp, p.second.tex, p.second.src);
+        }
+    } 
+}
+
+
+int VisualEffect::addPreLine (const int dur, const int startx, const int starty, const int endx,
+        const int endy, const Uint8 r, const Uint8 g, const Uint8 b, const Uint8 a) {
+    preLines[++preLineId] = {dur, startx, starty, endx, endy, r, g, b, a};
+    return preLineId;
+}
+
+int VisualEffect::addPostLine(const int dur, const int startx, const int starty, const int endx,
+        const int endy, const Uint8 r, const Uint8 g, const Uint8 b, const Uint8 a) {
+    preLines[++preLineId] = {dur, startx, starty, endx, endy, r, g, b, a};
+    return postLineId;
+}
+
+int VisualEffect::addPreRect(const int dur, const SDL_Rect &dest, const Uint8 r,
+        const Uint8 g, const Uint8 b, const Uint8 a) {
+    preRects[++preRectId] = {dur, dest, r, g, b, a};
+    return preRectId;
+}
+
+int VisualEffect::addPostRect(const int dur, const SDL_Rect &dest, const Uint8 r,
+        const Uint8 g, const Uint8 b, const Uint8 a) {
+    postRects[++postRectId] = {dur, dest, r, g, b, a};
+    return postRectId;
+}
+
+int VisualEffect::addPreTex(const int dur, const SDL_Rect &src, const SDL_Rect &dest, const TEXTURES tex) {
+    preTex[++preTexId] = {dur, tex, src, dest};
+    return preTexId;
+}
+
+int VisualEffect::addPostTex(const int dur, const SDL_Rect &src, const SDL_Rect &dest, const TEXTURES tex) {
+    postTex[++postTexId] = {dur, tex, src, dest};
+    return postTexId;
+}
+
+void VisualEffect::removePreLine(const int id) {
+    preLines.erase(id);
+}
+
+void VisualEffect::removePreRect(const int id) {
+    preRects.erase(id);
+}
+
+void VisualEffect::removePreTex(const int id) {
+    preTex.erase(id);
+}
+
+void VisualEffect::removePostLine(const int id) {
+    postLines.erase(id);
+}
+
+void VisualEffect::removePostRect(const int id) {
+    postRects.erase(id);
+}
+
+void VisualEffect::removePostTex(const int id) {
+    postTex.erase(id);
+}
+

--- a/src/sprites/VisualEffect.cpp
+++ b/src/sprites/VisualEffect.cpp
@@ -4,118 +4,248 @@
 
 VisualEffect VisualEffect::sInstance;
 
+/**
+ * Developer: Isaac Morneau
+ * Designer: Isaac Morneau
+ * Date: March 25, 2017
+ * Notes:
+ * sets the ids to 0 the rest can be default initialized
+ */
 VisualEffect::VisualEffect():preLineId(0), preRectId(0), preTexId(0), postLineId(0),
-    postRectId(0), postTexId(0) { }
+    postRectId(0), postTexId(0) {}
 
+/**
+ * Developer: Isaac Morneau
+ * Designer: Isaac Morneau
+ * Date: March 25, 2017
+ * Notes:
+ * helper function to calculate the screen rect based on the camera
+ */
 inline const SDL_Rect relative(const SDL_Rect& dest, const SDL_Rect& camera){
     return {dest.x - camera.x, dest.y - camera.y, dest.w, dest.h};
 }
 
+/**
+ * Developer: Isaac Morneau
+ * Designer: Isaac Morneau
+ * Date: March 25, 2017
+ * Notes:
+ * render and remove timed out effects 
+ */
 void VisualEffect::renderPreEntity(const SDL_Rect &camera) {
     auto& renderer = Renderer::instance();
     SDL_Renderer *rend = renderer.getRenderer();
-    for (auto& p : preLines) {
-        if (--p.second.dur > 0) {
-            SDL_SetRenderDrawColor(rend, p.second.r, p.second.g, p.second.b, p.second.a);
-            SDL_RenderDrawLine(rend, p.second.x - camera.x, p.second.y - camera.y,
-                    p.second.ex - camera.x, p.second.ey - camera.y);
+    for (auto p = preLines.begin(); p != preLines.end();) {
+        if (--p->second.dur > 0) {
+            SDL_SetRenderDrawColor(rend, p->second.r, p->second.g, p->second.b, p->second.a);
+            SDL_RenderDrawLine(rend, p->second.x - camera.x, p->second.y - camera.y,
+                    p->second.ex - camera.x, p->second.ey - camera.y);
+            ++p;
+        } else {
+            p = preLines.erase(p);
         }
     }
-    for (auto& p : preRects) {
-        if (--p.second.dur > 0) {
-            SDL_SetRenderDrawColor(rend, p.second.r, p.second.g, p.second.b, p.second.a);
-            const SDL_Rect temp = relative(p.second.s, camera);
+    for (auto p = preRects.begin(); p != preRects.end();) {
+        if (--p->second.dur > 0) {
+            SDL_SetRenderDrawColor(rend, p->second.r, p->second.g, p->second.b, p->second.a);
+            const SDL_Rect temp = relative(p->second.s, camera);
             SDL_RenderDrawRect(rend, &temp);
+            ++p;
+        } else {
+            p = preRects.erase(p);
         }
     } 
-    for (auto& p : preTex) {
-        if (--p.second.dur > 0) {
-            const SDL_Rect temp = relative(p.second.dest, camera);
-            renderer.render(temp, p.second.tex, p.second.src);
+    for (auto p = preTex.begin(); p != preTex.end();) {
+        if (--p->second.dur > 0) {
+            const SDL_Rect temp = relative(p->second.dest, camera);
+            renderer.render(temp, p->second.tex, p->second.src);
+            ++p;
+        } else {
+            p = preTex.erase(p);
         }
-    } 
+    }
 }
 
+/**
+ * Developer: Isaac Morneau
+ * Designer: Isaac Morneau
+ * Date: March 25, 2017
+ * Notes:
+ * render and remove timed out effects 
+ */
 void VisualEffect::renderPostEntity(const SDL_Rect &camera) {
     auto& renderer = Renderer::instance();
     SDL_Renderer *rend = renderer.getRenderer();
-    for (auto& p : postLines) {
-        if (--p.second.dur > 0) {
-            SDL_SetRenderDrawColor(rend, p.second.r, p.second.g, p.second.b, p.second.a);
-            SDL_RenderDrawLine(rend, p.second.x - camera.x, p.second.y - camera.y,
-                    p.second.ex - camera.x, p.second.ey - camera.y);
+    for (auto p = postLines.begin(); p != postLines.end();) {
+        if (--p->second.dur > 0) {
+            SDL_SetRenderDrawColor(rend, p->second.r, p->second.g, p->second.b, p->second.a);
+            SDL_RenderDrawLine(rend, p->second.x - camera.x, p->second.y - camera.y,
+                    p->second.ex - camera.x, p->second.ey - camera.y);
+            ++p;
+        } else {
+            p = postLines.erase(p);
         }
     }
-    for (auto& p : postRects) {
-        if (--p.second.dur > 0) {
-            SDL_SetRenderDrawColor(rend, p.second.r, p.second.g, p.second.b, p.second.a);
-            const SDL_Rect temp = relative(p.second.s, camera);
+    for (auto p = postRects.begin(); p != postRects.end();) {
+        if (--p->second.dur > 0) {
+            SDL_SetRenderDrawColor(rend, p->second.r, p->second.g, p->second.b, p->second.a);
+            const SDL_Rect temp = relative(p->second.s, camera);
             SDL_RenderDrawRect(rend, &temp);
+            ++p;
+        } else {
+            p = postRects.erase(p);
         }
     } 
-    for (auto& p : postTex) {
-        if (--p.second.dur > 0) {
-            const SDL_Rect temp = relative(p.second.dest, camera);
-            renderer.render(temp, p.second.tex, p.second.src);
+    for (auto p = postTex.begin(); p != postTex.end();) {
+        if (--p->second.dur > 0) {
+            const SDL_Rect temp = relative(p->second.dest, camera);
+            renderer.render(temp, p->second.tex, p->second.src);
+            ++p;
+        } else {
+            p = postTex.erase(p);
         }
-    } 
+    }
 }
 
 
+/**
+ * Developer: Isaac Morneau
+ * Designer: Isaac Morneau
+ * Date: March 25, 2017
+ * Notes:
+ * add a line effect
+ */
 int VisualEffect::addPreLine (const int dur, const int startx, const int starty, const int endx,
         const int endy, const Uint8 r, const Uint8 g, const Uint8 b, const Uint8 a) {
     preLines[++preLineId] = {dur, startx, starty, endx, endy, r, g, b, a};
     return preLineId;
 }
 
+/**
+ * Developer: Isaac Morneau
+ * Designer: Isaac Morneau
+ * Date: March 25, 2017
+ * Notes:
+ * add a line effect
+ */
 int VisualEffect::addPostLine(const int dur, const int startx, const int starty, const int endx,
         const int endy, const Uint8 r, const Uint8 g, const Uint8 b, const Uint8 a) {
-    preLines[++preLineId] = {dur, startx, starty, endx, endy, r, g, b, a};
+    postLines[++postLineId] = {dur, startx, starty, endx, endy, r, g, b, a};
     return postLineId;
 }
 
+/**
+ * Developer: Isaac Morneau
+ * Designer: Isaac Morneau
+ * Date: March 25, 2017
+ * Notes:
+ * add a rect effect
+ */
 int VisualEffect::addPreRect(const int dur, const SDL_Rect &dest, const Uint8 r,
         const Uint8 g, const Uint8 b, const Uint8 a) {
     preRects[++preRectId] = {dur, dest, r, g, b, a};
     return preRectId;
 }
 
+/**
+ * Developer: Isaac Morneau
+ * Designer: Isaac Morneau
+ * Date: March 25, 2017
+ * Notes:
+ * add a rect effect
+ */
 int VisualEffect::addPostRect(const int dur, const SDL_Rect &dest, const Uint8 r,
         const Uint8 g, const Uint8 b, const Uint8 a) {
     postRects[++postRectId] = {dur, dest, r, g, b, a};
     return postRectId;
 }
 
+/**
+ * Developer: Isaac Morneau
+ * Designer: Isaac Morneau
+ * Date: March 25, 2017
+ * Notes:
+ * add a texture effect
+ */
 int VisualEffect::addPreTex(const int dur, const SDL_Rect &src, const SDL_Rect &dest, const TEXTURES tex) {
     preTex[++preTexId] = {dur, tex, src, dest};
     return preTexId;
 }
 
+/**
+ * Developer: Isaac Morneau
+ * Designer: Isaac Morneau
+ * Date: March 25, 2017
+ * Notes:
+ * add a texture effect
+ */
 int VisualEffect::addPostTex(const int dur, const SDL_Rect &src, const SDL_Rect &dest, const TEXTURES tex) {
     postTex[++postTexId] = {dur, tex, src, dest};
     return postTexId;
 }
 
+/**
+ * Developer: Isaac Morneau
+ * Designer: Isaac Morneau
+ * Date: March 25, 2017
+ * Notes:
+ * cancel effect with given id
+ */
 void VisualEffect::removePreLine(const int id) {
     preLines.erase(id);
 }
 
+/**
+ * Developer: Isaac Morneau
+ * Designer: Isaac Morneau
+ * Date: March 25, 2017
+ * Notes:
+ * cancel effect with given id
+ */
 void VisualEffect::removePreRect(const int id) {
     preRects.erase(id);
 }
 
+/**
+ * Developer: Isaac Morneau
+ * Designer: Isaac Morneau
+ * Date: March 25, 2017
+ * Notes:
+ * cancel effect with given id
+ */
 void VisualEffect::removePreTex(const int id) {
     preTex.erase(id);
 }
 
+/**
+ * Developer: Isaac Morneau
+ * Designer: Isaac Morneau
+ * Date: March 25, 2017
+ * Notes:
+ * cancel effect with given id
+ */
 void VisualEffect::removePostLine(const int id) {
     postLines.erase(id);
 }
 
+/**
+ * Developer: Isaac Morneau
+ * Designer: Isaac Morneau
+ * Date: March 25, 2017
+ * Notes:
+ * cancel effect with given id
+ */
 void VisualEffect::removePostRect(const int id) {
     postRects.erase(id);
 }
 
+/**
+ * Developer: Isaac Morneau
+ * Designer: Isaac Morneau
+ * Date: March 25, 2017
+ * Notes:
+ * cancel effect with given id
+ */
 void VisualEffect::removePostTex(const int id) {
     postTex.erase(id);
 }

--- a/src/sprites/VisualEffect.h
+++ b/src/sprites/VisualEffect.h
@@ -6,8 +6,27 @@
 #include "SpriteTypes.h"
 
 
+/**
+ * Developer: Isaac Morneau
+ * Designer: Isaac Morneau
+ * Date: March 25, 2017
+ *
+ * Notes:
+ * This Singleton's job is to manage temporary visual effects
+ * It can draw Textures, lines, and rectangles either before or after the entites in GameManager
+ * with the pre and post commands respecitively.
+ *
+ * All additions return the respective ID and can be used to cancel the effect early by removing it.
+ *
+ * All positions taken in are in world coords not screen coords.
+ */
 class VisualEffect {
     public:
+        /**
+         * Developer: Isaac Morneau
+         * Designer: Isaac Morneau
+         * Date: March 25, 2017
+         */
         static VisualEffect& instance(){
             return sInstance;
         }
@@ -31,8 +50,6 @@ class VisualEffect {
         int addPreTex(const int dur, const SDL_Rect &src, const SDL_Rect &dest, const TEXTURES tex);
 
         int addPostTex(const int dur, const SDL_Rect &src, const SDL_Rect &dest, const TEXTURES tex);
-        
-
 
 
         void removePreLine(const int id);
@@ -57,11 +74,14 @@ class VisualEffect {
 
         //internal classes to manage the different types
         struct Line {
+            //time to display
             int dur;
-            
+            //start x,y
             int x, y;
+            //end x, y
             int ex, ey;
 
+            //red green blue alpha
             Uint8 r;
             Uint8 g;
             Uint8 b;
@@ -69,10 +89,12 @@ class VisualEffect {
         };
 
         struct Rect {
+            //time to display
             int dur;
-            
+            //rect to draw
             SDL_Rect s;
             
+            //red green blue alpha
             Uint8 r;
             Uint8 g;
             Uint8 b;
@@ -80,10 +102,13 @@ class VisualEffect {
         };
 
         struct Tex {
+            //time to display
             int dur;
-
+            //the texture enum to display
             TEXTURES tex;
 
+            //src texture to display from
+            //dest location to display to
             SDL_Rect src, dest;
         };
 

--- a/src/sprites/VisualEffect.h
+++ b/src/sprites/VisualEffect.h
@@ -1,0 +1,107 @@
+#ifndef VISUALEFFECT_H
+#define VISUALEFFECT_H
+
+#include <SDL2/SDL.h>
+#include <unordered_map>
+#include "SpriteTypes.h"
+
+
+class VisualEffect {
+    public:
+        static VisualEffect& instance(){
+            return sInstance;
+        }
+
+        void renderPreEntity(const SDL_Rect &camera);
+        
+        void renderPostEntity(const SDL_Rect &camera);
+
+        int addPreLine(const int dur, const int startx, const int starty, const int endx,
+            const int endy, const Uint8 r = 0, const Uint8 g = 0, const Uint8 b = 0, const Uint8 a = 255);
+
+        int addPostLine(const int dur, const int startx, const int starty, const int endx,
+            const int endy, const Uint8 r = 0, const Uint8 g = 0, const Uint8 b = 0, const Uint8 a = 255);
+
+        int addPreRect(const int dur, const SDL_Rect &dest, const Uint8 r = 0, const Uint8 g = 0,
+            const Uint8 b = 0, const Uint8 a = 255);
+
+        int addPostRect(const int dur, const SDL_Rect &dest, const Uint8 r = 0, const Uint8 g = 0,
+            const Uint8 b = 0, const Uint8 a = 255);
+
+        int addPreTex(const int dur, const SDL_Rect &src, const SDL_Rect &dest, const TEXTURES tex);
+
+        int addPostTex(const int dur, const SDL_Rect &src, const SDL_Rect &dest, const TEXTURES tex);
+        
+
+
+
+        void removePreLine(const int id);
+        
+        void removePreRect(const int id);
+        
+        void removePreTex(const int id);
+
+        void removePostLine(const int id);
+
+        void removePostRect(const int id);
+
+        void removePostTex(const int id);
+
+
+    private:
+
+        VisualEffect();
+        ~VisualEffect() = default;
+
+        static VisualEffect sInstance;
+
+        //internal classes to manage the different types
+        struct Line {
+            int dur;
+            
+            int x, y;
+            int ex, ey;
+
+            Uint8 r;
+            Uint8 g;
+            Uint8 b;
+            Uint8 a;
+        };
+
+        struct Rect {
+            int dur;
+            
+            SDL_Rect s;
+            
+            Uint8 r;
+            Uint8 g;
+            Uint8 b;
+            Uint8 a;
+        };
+
+        struct Tex {
+            int dur;
+
+            TEXTURES tex;
+
+            SDL_Rect src, dest;
+        };
+
+        int preLineId;
+        int preRectId;
+        int preTexId;
+
+        int postLineId;
+        int postRectId;
+        int postTexId;
+        
+        std::unordered_map<int, Line> preLines;
+        std::unordered_map<int, Rect> preRects;
+        std::unordered_map<int, Tex> preTex;
+
+        std::unordered_map<int, Line> postLines;
+        std::unordered_map<int, Rect> postRects;
+        std::unordered_map<int, Tex> postTex;
+};
+
+#endif

--- a/src/sprites/VisualEffect.h
+++ b/src/sprites/VisualEffect.h
@@ -21,7 +21,7 @@
  * All positions taken in are in world coords not screen coords.
  */
 class VisualEffect {
-    public:
+public:
         /**
          * Developer: Isaac Morneau
          * Designer: Isaac Morneau
@@ -65,7 +65,7 @@ class VisualEffect {
         void removePostTex(const int id);
 
 
-    private:
+private:
 
         VisualEffect();
         ~VisualEffect() = default;


### PR DESCRIPTION
Added the singleton for managing temporary visual effects with an example in instant fire weapon to show the effects in action.
Allows _pre_ and _post_ entity effects which results in either effects behind entities or in front of entities depending on what is needed.

I added support for:
- lines (shooting)
- rectangles (selection boxes?)
- textures (dead bodies)

_Also, as a side note I changed the render to not goes as overboard on the static everything and removed the pointer return (yay cleaner code)._